### PR TITLE
Fix and extend QuerySet annotation alias support

### DIFF
--- a/internal/analysis/definition.go
+++ b/internal/analysis/definition.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/amirhasanzadehpy/Pogo/internal/schema"
@@ -126,4 +127,457 @@ func referenceIsCode(source []byte, reference ByteRange) bool {
 		}
 	}
 	return true
+}
+
+// ResolveAnnotationAliasDefinition locates the .annotate()/.alias() keyword argument that
+// introduced the QuerySet annotation referenced at offset, scanning the literal call chain
+// that produced the current value. Annotation aliases are a syntactic, same-file construct
+// (not part of the schema graph), so this returns a plain in-document range rather than a
+// schema.SourceRange.
+func ResolveAnnotationAliasDefinition(source []byte, offset int, graph *schema.Graph, syntax []SyntaxStatement, filePath string) (ByteRange, bool) {
+	ref, _, ok := resolveAnnotationUsage(source, offset, graph, syntax, filePath)
+	if !ok {
+		return ByteRange{}, false
+	}
+	return ref.span, true
+}
+
+// AnnotationReturnType infers the Python return type of the QuerySet annotation referenced at
+// offset (e.g. "int" for Count(...), "bool" for Exists(...), or a field's Django type when the
+// annotation wraps a resolvable model field such as Sum("price") or F("price")). It returns
+// false when the alias exists but its expression isn't one of the recognized shapes.
+func AnnotationReturnType(source []byte, offset int, graph *schema.Graph, syntax []SyntaxStatement, filePath string) (string, bool) {
+	ref, canonicalLabel, ok := resolveAnnotationUsage(source, offset, graph, syntax, filePath)
+	if !ok {
+		return "", false
+	}
+	return inferAnnotationReturnType(string(source[ref.value.Start:ref.value.End]), canonicalLabel, graph)
+}
+
+// resolveAnnotationUsage locates the .annotate()/.alias() keyword argument backing the
+// annotation alias referenced at offset, covering every shape the query-path analyzer surfaces
+// an annotation alias through: values()/values_list() and filter()/exclude()/get() path
+// segments (including the single-segment ContextQueryKeyword form and lookups nested in Q(...)),
+// and attribute access on a resolved model instance (obj.alias).
+func resolveAnnotationUsage(source []byte, offset int, graph *schema.Graph, syntax []SyntaxStatement, filePath string) (annotationAliasRef, string, bool) {
+	if graph == nil || offset < 0 || offset > len(source) {
+		return annotationAliasRef{}, "", false
+	}
+	context, ok := AnalyzeSyntaxFile(source, offset, graph, syntax, filePath)
+	if !ok || context.Identifier == "" || !isAnnotationAlias(context.Value.Annotations, context.Identifier) {
+		return annotationAliasRef{}, "", false
+	}
+	var chain ByteRange
+	switch context.Kind {
+	case ContextInstanceMember:
+		replacement := identifierRange(source, offset)
+		if replacement.Start == 0 || source[replacement.Start-1] != '.' {
+			return annotationAliasRef{}, "", false
+		}
+		chain = expressionBefore(source, replacement.Start-1)
+	case ContextQueryKeyword:
+		imports, _ := buildEnvironmentAtPath(source[:offset], graph, syntax, offset, filePath)
+		receiver, ok := queryKeywordReceiver(source, offset, imports)
+		if !ok {
+			return annotationAliasRef{}, "", false
+		}
+		chain = receiver
+	case ContextORMPath:
+		if context.Path == nil || context.Path.OnSeparator || context.Path.ActiveSegment != 0 {
+			return annotationAliasRef{}, "", false
+		}
+		if context.Path.Mode != PathLookup && context.Path.Mode != PathProjection {
+			return annotationAliasRef{}, "", false
+		}
+		receiver, ok := ormPathChainReceiver(source, offset, graph, syntax, filePath)
+		if !ok {
+			return annotationAliasRef{}, "", false
+		}
+		chain = receiver
+	default:
+		return annotationAliasRef{}, "", false
+	}
+	ref, ok := findChainAnnotationRef(source, chain, context.Identifier)
+	if !ok {
+		return annotationAliasRef{}, "", false
+	}
+	return ref, context.Value.CanonicalLabel, true
+}
+
+// ormPathChainReceiver finds the queryset chain a ContextORMPath string segment belongs to.
+// For a direct string/keyword path argument (e.g. .values("x"), .filter(x=1)) that's simply the
+// enclosing call's receiver. For a segment nested inside an expression function's argument
+// (e.g. F("x") or Sum("x") inside .annotate(...)), it looks past that expression call to the
+// annotate()/alias()/aggregate() call that actually owns the chain.
+func ormPathChainReceiver(source []byte, offset int, graph *schema.Graph, syntax []SyntaxStatement, filePath string) (ByteRange, bool) {
+	if expression, ok := enclosingFunctionCall(source, offset); ok {
+		imports, _ := buildEnvironmentAtPath(source[:offset], graph, syntax, offset, filePath)
+		if isAnnotationExpressionFunction(expandImport(expression.name, imports)) {
+			call, ok := enclosingCallBefore(source, offset, expression.opening)
+			if !ok || call.method != "annotate" && call.method != "alias" && call.method != "aggregate" {
+				return ByteRange{}, false
+			}
+			return call.receiver, true
+		}
+	}
+	call, ok := enclosingCall(source, offset)
+	if !ok {
+		return ByteRange{}, false
+	}
+	return call.receiver, true
+}
+
+// queryKeywordReceiver finds the receiver of the filter()/exclude()/get() call backing a bare
+// (no "__") keyword segment, looking past an enclosing Q(...) wrapper when present.
+func queryKeywordReceiver(source []byte, offset int, imports map[string]string) (ByteRange, bool) {
+	if expression, ok := enclosingFunctionCall(source, offset); ok && expandImport(expression.name, imports) == "django.db.models.Q" {
+		call, ok := enclosingCallBefore(source, offset, expression.opening)
+		if !ok {
+			return ByteRange{}, false
+		}
+		return call.receiver, true
+	}
+	call, ok := enclosingCall(source, offset)
+	if !ok {
+		return ByteRange{}, false
+	}
+	return call.receiver, true
+}
+
+func findChainAnnotationRef(source []byte, chain ByteRange, name string) (annotationAliasRef, bool) {
+	if name == "" || chain.Start < 0 || chain.End > len(source) || chain.Start >= chain.End {
+		return annotationAliasRef{}, false
+	}
+	text := string(source[chain.Start:chain.End])
+	code := pythonCodeMask(source[chain.Start:chain.End], len(text))
+	depth := 0
+	var found annotationAliasRef
+	ok := false
+	for index := 0; index < len(text); index++ {
+		if index < len(code) && !code[index] {
+			continue
+		}
+		switch text[index] {
+		case '(', '[', '{':
+			depth++
+			continue
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 || text[index] != '.' {
+			continue
+		}
+		nameStart := index + 1
+		nameEnd := nameStart
+		for nameEnd < len(text) && isIdentifierByte(text[nameEnd]) {
+			nameEnd++
+		}
+		if method := text[nameStart:nameEnd]; method != "annotate" && method != "alias" {
+			continue
+		}
+		callStart := nameEnd
+		for callStart < len(text) && (text[callStart] == ' ' || text[callStart] == '\t') {
+			callStart++
+		}
+		if callStart >= len(text) || text[callStart] != '(' {
+			continue
+		}
+		callEnd, matched := skipCall(text, callStart)
+		if !matched {
+			break
+		}
+		for _, ref := range annotationAliasRefs(text[callStart+1 : callEnd-1]) {
+			if ref.name == name {
+				base := chain.Start + callStart + 1
+				found = annotationAliasRef{
+					name:  ref.name,
+					span:  ByteRange{Start: base + ref.span.Start, End: base + ref.span.End},
+					value: ByteRange{Start: base + ref.value.Start, End: base + ref.value.End},
+				}
+				ok = true
+			}
+		}
+		index = callEnd - 1
+	}
+	return found, ok
+}
+
+type annotationAliasRef struct {
+	name  string
+	span  ByteRange
+	value ByteRange
+}
+
+func annotationAliasRefs(args string) []annotationAliasRef {
+	var refs []annotationAliasRef
+	depth := 0
+	segStart := 0
+	var quote byte
+	escaped := false
+	for index := 0; index <= len(args); index++ {
+		var ch byte
+		if index < len(args) {
+			ch = args[index]
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',', 0:
+			if depth == 0 {
+				if ref, ok := keywordArgRef(args, segStart, index); ok {
+					refs = append(refs, ref)
+				}
+				segStart = index + 1
+			}
+		}
+	}
+	return refs
+}
+
+func keywordArgRef(args string, start, end int) (annotationAliasRef, bool) {
+	trimStart, trimEnd := start, end
+	for trimStart < trimEnd && isSpace(args[trimStart]) {
+		trimStart++
+	}
+	for trimEnd > trimStart && isSpace(args[trimEnd-1]) {
+		trimEnd--
+	}
+	segment := args[trimStart:trimEnd]
+	for index := 0; index < len(segment); index++ {
+		switch segment[index] {
+		case '(', '[', '{':
+			return annotationAliasRef{}, false
+		case '=':
+			if index == 0 {
+				return annotationAliasRef{}, false
+			}
+			prev := segment[index-1]
+			if prev == '!' || prev == '<' || prev == '>' {
+				return annotationAliasRef{}, false
+			}
+			next := byte(0)
+			if index+1 < len(segment) {
+				next = segment[index+1]
+			}
+			if next == '=' {
+				return annotationAliasRef{}, false
+			}
+			name := strings.TrimSpace(segment[:index])
+			if !identifierText(name) {
+				return annotationAliasRef{}, false
+			}
+			valueStart := trimStart + index + 1
+			for valueStart < trimEnd && isSpace(args[valueStart]) {
+				valueStart++
+			}
+			return annotationAliasRef{
+				name:  name,
+				span:  ByteRange{Start: trimStart, End: trimStart + len(name)},
+				value: ByteRange{Start: valueStart, End: trimEnd},
+			}, true
+		}
+	}
+	return annotationAliasRef{}, false
+}
+
+// inferAnnotationReturnType maps a single .annotate()/.alias() expression to the Python type its
+// values will have when read back from a row. It only recognizes a fixed set of common Django
+// aggregate/expression shapes; anything else (combined expressions, custom Func subclasses
+// without an explicit output_field, ...) is left unresolved rather than guessed at.
+func inferAnnotationReturnType(valueText string, canonicalLabel string, graph *schema.Graph) (string, bool) {
+	name, args, ok := topLevelCall(strings.TrimSpace(valueText))
+	if !ok {
+		return "", false
+	}
+	for _, ref := range annotationAliasRefs(args) {
+		if ref.name == "output_field" {
+			if fieldClass, ok := topLevelCallName(strings.TrimSpace(args[ref.value.Start:ref.value.End])); ok {
+				return fieldClass, true
+			}
+		}
+	}
+	switch baseFunctionName(name) {
+	case "Count":
+		return "int", true
+	case "Exists":
+		return "bool", true
+	case "Concat":
+		return "str", true
+	case "Length":
+		return "int", true
+	case "Sum", "Avg", "Min", "Max", "F":
+		fieldPath, ok := firstStringLiteralArg(args)
+		if !ok {
+			return "", false
+		}
+		return resolveFieldType(canonicalLabel, fieldPath, graph)
+	case "Value":
+		literal, ok := firstPositionalArg(args)
+		if !ok {
+			return "", false
+		}
+		return literalPythonType(literal)
+	default:
+		return "", false
+	}
+}
+
+func topLevelCall(expr string) (name string, args string, ok bool) {
+	open := strings.IndexByte(expr, '(')
+	if open < 0 || expr == "" || expr[len(expr)-1] != ')' {
+		return "", "", false
+	}
+	name = strings.TrimSpace(expr[:open])
+	if name == "" || !isDottedIdentifier(name) {
+		return "", "", false
+	}
+	end, matched := skipCall(expr, open)
+	if !matched || end != len(expr) {
+		return "", "", false
+	}
+	return name, expr[open+1 : end-1], true
+}
+
+func topLevelCallName(expr string) (string, bool) {
+	name, _, ok := topLevelCall(expr)
+	if !ok {
+		return "", false
+	}
+	return baseFunctionName(name), true
+}
+
+func isDottedIdentifier(name string) bool {
+	for _, part := range strings.Split(name, ".") {
+		if !identifierText(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func baseFunctionName(name string) string {
+	if index := strings.LastIndexByte(name, '.'); index >= 0 {
+		return name[index+1:]
+	}
+	return name
+}
+
+func firstPositionalArg(args string) (string, bool) {
+	depth := 0
+	var quote byte
+	escaped := false
+	for index := 0; index < len(args); index++ {
+		ch := args[index]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if ch == '\\' {
+				escaped = true
+			} else if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return strings.TrimSpace(args[:index]), true
+			}
+		}
+	}
+	if strings.TrimSpace(args) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(args), true
+}
+
+func firstStringLiteralArg(args string) (string, bool) {
+	literal, ok := firstPositionalArg(args)
+	if !ok || len(literal) < 2 {
+		return "", false
+	}
+	quote := literal[0]
+	if quote != '\'' && quote != '"' || literal[len(literal)-1] != quote {
+		return "", false
+	}
+	return literal[1 : len(literal)-1], true
+}
+
+func resolveFieldType(canonicalLabel string, fieldPath string, graph *schema.Graph) (string, bool) {
+	if canonicalLabel == "" || fieldPath == "" || graph == nil {
+		return "", false
+	}
+	model := canonicalLabel
+	segments := strings.Split(fieldPath, "__")
+	for index, segment := range segments {
+		access, ok := graph.QueryAccess(model, segment)
+		if !ok || access.Field == nil {
+			return "", false
+		}
+		if index == len(segments)-1 {
+			return access.Field.Type(), true
+		}
+		related, ok := access.Field.RelatedModel()
+		if !ok {
+			return "", false
+		}
+		model = related
+	}
+	return "", false
+}
+
+func literalPythonType(literal string) (string, bool) {
+	if literal == "" {
+		return "", false
+	}
+	switch literal {
+	case "True", "False":
+		return "bool", true
+	case "None":
+		return "None", true
+	}
+	if len(literal) >= 2 {
+		quote := literal[0]
+		if (quote == '\'' || quote == '"') && literal[len(literal)-1] == quote {
+			return "str", true
+		}
+	}
+	if _, err := strconv.Atoi(literal); err == nil {
+		return "int", true
+	}
+	if _, err := strconv.ParseFloat(literal, 64); err == nil {
+		return "float", true
+	}
+	return "", false
 }

--- a/internal/analysis/definition_test.go
+++ b/internal/analysis/definition_test.go
@@ -1,6 +1,9 @@
 package analysis
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResolveDefinitionSyntaxAcrossORMReferences(t *testing.T) {
 	graph := inferenceTestGraph(t)
@@ -97,6 +100,166 @@ func TestResolveDefinitionSyntaxRejectsUnknownReferences(t *testing.T) {
 		snapshot, _ := store.Snapshot("file:///unknown.py")
 		if sourceRange, ok := ResolveDefinitionSyntax(source, offset, graph, snapshot.Syntax); ok {
 			t.Fatalf("ResolveDefinitionSyntax(%q) = %#v", sourceWithCursor, sourceRange)
+		}
+		store.CloseAll()
+	}
+}
+
+func TestResolveAnnotationAliasDefinition(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"values_list argument", "from myapp.models import Author\nAuthor.objects.annotate(count=Count('id')).values_list(\"pk\", \"cou|nt\")\n"},
+		{"filter lookup", "from myapp.models import Author\nAuthor.objects.annotate(count=Count('id')).filter(cou|nt__gt=1)\n"},
+		{"through first()", "from myapp.models import Author\nAuthor.objects.annotate(has_books=Exists(p)).first().has_boo|ks\n"},
+		{"second annotate call", "from myapp.models import Author\nAuthor.objects.annotate(a=Value(1)).annotate(b=Value(2)).values_list(\"|b\")\n"},
+		{"F() argument referencing an earlier annotate", "from django.db.models import F\nfrom myapp.models import Author\nAuthor.objects.annotate(count=Count('id')).annotate(total=F(\"cou|nt\") + 1)\n"},
+		{"Sum() argument referencing an earlier annotate", "from django.db.models import Sum\nfrom myapp.models import Author\nAuthor.objects.annotate(a=Value(1)).annotate(b=Sum(\"|a\"))\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, offset := sourceAtCursor(t, test.source)
+			store, err := NewStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.CloseAll()
+			if err := store.Open("file:///annotate-def.py", 1, string(source)); err != nil {
+				t.Fatal(err)
+			}
+			snapshot, _ := store.Snapshot("file:///annotate-def.py")
+			sourceRange, ok := ResolveAnnotationAliasDefinition(source, offset, graph, snapshot.Syntax, "")
+			if !ok {
+				t.Fatalf("ResolveAnnotationAliasDefinition() ok = false")
+			}
+			after := string(source[sourceRange.End:min(sourceRange.End+1, len(source))])
+			if after != "=" {
+				t.Fatalf("resolved range %q does not point at a keyword name (followed by %q)", source[sourceRange.Start:sourceRange.End], after)
+			}
+		})
+	}
+}
+
+func TestAnnotationReturnType(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"count", "from myapp.models import Book\nBook.objects.annotate(count=Count(\"id\")).values_list(\"cou|nt\")\n", "int"},
+		{"exists", "from myapp.models import Book\nBook.objects.annotate(has_author=Exists(x)).filter(has_autho|r=True)\n", "bool"},
+		{"sum resolves field type", "from myapp.models import Book\nBook.objects.annotate(total=Sum(\"id\")).values_list(\"tota|l\")\n", "django.db.models.fields.BigAutoField"},
+		{"f resolves field type", "from myapp.models import Book\nBook.objects.annotate(t=F(\"title\")).values_list(\"|t\")\n", "django.db.models.fields.CharField"},
+		{"value int literal", "from myapp.models import Book\nBook.objects.annotate(one=Value(1)).values_list(\"on|e\")\n", "int"},
+		{"value string literal", "from myapp.models import Book\nBook.objects.annotate(label=Value(\"x\")).values_list(\"labe|l\")\n", "str"},
+		{"explicit output_field wins", "from myapp.models import Book\nBook.objects.annotate(total=Sum(\"id\", output_field=FloatField())).values_list(\"tota|l\")\n", "FloatField"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, offset := sourceAtCursor(t, test.source)
+			store, err := NewStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.CloseAll()
+			if err := store.Open("file:///annotate-type.py", 1, string(source)); err != nil {
+				t.Fatal(err)
+			}
+			snapshot, _ := store.Snapshot("file:///annotate-type.py")
+			got, ok := AnnotationReturnType(source, offset, graph, snapshot.Syntax, "")
+			if !ok || got != test.want {
+				t.Fatalf("AnnotationReturnType() = %q, %v; want %q", got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveAnnotationAliasDefinitionAcrossMultiKeywordAnnotateChain(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	source := "from django.db.models import Count, F\n" +
+		"from myapp.models import Author\n" +
+		"(\n" +
+		"    Author.objects.prefetch_related(\"book\")\n" +
+		"    .annotate(\n" +
+		"        email_invitation_count=Count(\"a\", distinct=True),\n" +
+		"        invitation_count=Count(\"b\", distinct=True),\n" +
+		"        user_count=Count(\"c\", distinct=True) + 1,\n" +
+		"    )\n" +
+		"    .annotate(total=F(\"user_cou|nt\") + F(\"invitation_count\") + F(\"email_invitation_count\"))\n" +
+		"    .distinct()\n" +
+		")\n"
+	src, offset := sourceAtCursor(t, source)
+	store, err := NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.CloseAll()
+	if err := store.Open("file:///annotate-chain.py", 1, string(src)); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, _ := store.Snapshot("file:///annotate-chain.py")
+	sourceRange, ok := ResolveAnnotationAliasDefinition(src, offset, graph, snapshot.Syntax, "")
+	if !ok {
+		t.Fatalf("ResolveAnnotationAliasDefinition() ok = false")
+	}
+	text := string(src[sourceRange.Start:sourceRange.End])
+	after := string(src[sourceRange.End:min(sourceRange.End+1, len(src))])
+	if text != "user_count" || after != "=" {
+		t.Fatalf("resolved range = %q, followed by %q; want \"user_count\" followed by \"=\"", text, after)
+	}
+	returnType, ok := AnnotationReturnType(src, offset, graph, snapshot.Syntax, "")
+	if ok {
+		t.Fatalf("AnnotationReturnType() = %q, want unresolved (combined expression)", returnType)
+	}
+
+	invitationOffset := strings.Index(string(src), "F(\"invitation_count\")") + len("F(\"")
+	if returnType, ok := AnnotationReturnType(src, invitationOffset, graph, snapshot.Syntax, ""); !ok || returnType != "int" {
+		t.Fatalf("AnnotationReturnType(invitation_count) = %q, %v; want \"int\"", returnType, ok)
+	}
+}
+
+func TestAnnotationReturnTypeUnresolved(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	for _, sourceWithCursor := range []string{
+		"from myapp.models import Book\nBook.objects.annotate(t=F(\"bogus\")).values_list(\"|t\")",
+		"from myapp.models import Book\nBook.objects.annotate(t=F(\"id\") + F(\"id\")).values_list(\"|t\")",
+	} {
+		source, offset := sourceAtCursor(t, sourceWithCursor)
+		store, err := NewStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Open("file:///annotate-type-reject.py", 1, string(source)); err != nil {
+			t.Fatal(err)
+		}
+		snapshot, _ := store.Snapshot("file:///annotate-type-reject.py")
+		if got, ok := AnnotationReturnType(source, offset, graph, snapshot.Syntax, ""); ok {
+			t.Fatalf("AnnotationReturnType(%q) = %q, want unresolved", sourceWithCursor, got)
+		}
+		store.CloseAll()
+	}
+}
+
+func TestResolveAnnotationAliasDefinitionRejectsNonAnnotations(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	for _, sourceWithCursor := range []string{
+		"from myapp.models import Author\nAuthor.objects.filter(na|me='x')",
+		"from myapp.models import Author\nAuthor.objects.annotate(count=Count('id')).values_list(\"bog|us\")",
+	} {
+		source, offset := sourceAtCursor(t, sourceWithCursor)
+		store, err := NewStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Open("file:///annotate-def-reject.py", 1, string(source)); err != nil {
+			t.Fatal(err)
+		}
+		snapshot, _ := store.Snapshot("file:///annotate-def-reject.py")
+		if sourceRange, ok := ResolveAnnotationAliasDefinition(source, offset, graph, snapshot.Syntax, ""); ok {
+			t.Fatalf("ResolveAnnotationAliasDefinition(%q) = %#v", sourceWithCursor, sourceRange)
 		}
 		store.CloseAll()
 	}

--- a/internal/analysis/diagnostic.go
+++ b/internal/analysis/diagnostic.go
@@ -26,7 +26,7 @@ func DiagnoseORM(snapshot Snapshot, graph *schema.Graph) []ORMIssue {
 		return issues
 	}
 	for _, path := range staticORMPaths(snapshot, graph) {
-		problem, invalid := ValidatePath(graph, path.value.CanonicalLabel, path.mode, path.segments)
+		problem, invalid := ValidatePath(graph, path.value.CanonicalLabel, path.mode, path.segments, path.value.Annotations)
 		if !invalid {
 			continue
 		}

--- a/internal/analysis/diagnostic_test.go
+++ b/internal/analysis/diagnostic_test.go
@@ -25,6 +25,7 @@ func TestDiagnoseORMClassifiesStaticPaths(t *testing.T) {
 		{"leading argument comment", "Book.objects.filter(\n    # typo\n    titel=1\n)", IssueUnknownPathSegment, "titel"},
 		{"empty projection segment", "Book.objects.values(\"author____name\")", IssueUnknownPathSegment, "__"},
 		{"empty projection path", "Book.objects.values(\"\")", IssueUnknownPathSegment, ""},
+		{"unrelated field still flagged after annotate", "Book.objects.annotate(count=Count(\"id\")).values_list(\"bogus\")", IssueUnknownPathSegment, "bogus"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -65,6 +66,8 @@ func TestDiagnoseORMSuppressesValidDynamicAndIncompleteCode(t *testing.T) {
 		"Book.objects.order_by(\"missing\")",
 		"unknown.objects.filter(titel=1)",
 		"Book.catalog.filter(titel=1)",
+		"Book.objects.values(\"title\").annotate(count=Count(\"id\")).values_list(\"title\", \"count\")",
+		"Book.objects.annotate(count=Count(\"id\")).filter(count__gt=1)",
 	}
 	for _, expression := range tests {
 		t.Run(expression, func(t *testing.T) {

--- a/internal/analysis/infer.go
+++ b/internal/analysis/infer.go
@@ -26,6 +26,7 @@ type Value struct {
 	Kind           ValueKind
 	ManagerName    string
 	QuerySetClass  string
+	Annotations    []string
 }
 
 type ContextKind uint8
@@ -64,6 +65,7 @@ var (
 	asBindingPattern         = regexp.MustCompile(`(?m)\bas\s+(\([^\n)]*\)|[A-Za-z_][A-Za-z0-9_]*)`)
 	walrusBindingPattern     = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\s*:=`)
 	adminRegisterPattern     = regexp.MustCompile(`^@([A-Za-z_][A-Za-z0-9_.]*)\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*\)\s*$`)
+	forHeaderPattern         = regexp.MustCompile(`^\s*for\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\s+(.+)\s*:\s*$`)
 )
 
 const adminQuerySetBinding = "__pogo_admin_queryset__"
@@ -372,12 +374,18 @@ func buildEnvironment(source []byte, graph *schema.Graph, syntax []SyntaxStateme
 	return buildEnvironmentAtPath(source, graph, syntax, offset, "")
 }
 
+type forBinding struct {
+	variable string
+	iterable string
+}
+
 func buildEnvironmentAtPath(source []byte, graph *schema.Graph, syntax []SyntaxStatement, offset int, filePath string) (map[string]string, map[string]Value) {
 	imports := make(map[string]string)
 	values := make(map[string]Value)
 	var guardedBindings []string
 	var futureBindings []string
 	var opaqueBindings []string
+	var pendingForBindings []forBinding
 	lines := bytes.Split(source, []byte{'\n'})
 	if len(syntax) > 0 {
 		ordered := append([]SyntaxStatement(nil), syntax...)
@@ -407,6 +415,17 @@ func buildEnvironmentAtPath(source []byte, graph *schema.Graph, syntax []SyntaxS
 			inScope := statement.ScopeKind == "" || statement.ScopeStart == currentScope.ScopeStart && statement.ScopeEnd == currentScope.ScopeEnd && statement.ScopeKind == currentScope.ScopeKind
 			if statement.Guarded {
 				if inScope && (statement.Start < offset || currentScope.ScopeKind == "function_definition") {
+					// If the cursor is inside a for-in statement, infer the loop variable from the iterable.
+					if statement.Start < offset && offset <= statement.End {
+						firstLine := statement.Text
+						if nl := strings.IndexByte(firstLine, '\n'); nl >= 0 {
+							firstLine = firstLine[:nl]
+						}
+						if match := forHeaderPattern.FindStringSubmatch(firstLine); match != nil {
+							pendingForBindings = append(pendingForBindings, forBinding{variable: match[1], iterable: strings.TrimSpace(match[2])})
+							continue
+						}
+					}
 					guardedBindings = append(guardedBindings, statementBindingNames(statement.Text)...)
 				}
 				continue
@@ -480,6 +499,17 @@ func buildEnvironmentAtPath(source []byte, graph *schema.Graph, syntax []SyntaxS
 			delete(imports, name)
 			continue
 		}
+		if match := forHeaderPattern.FindStringSubmatch(line); match != nil {
+			iterable := resolveExpression(strings.TrimSpace(match[2]), imports, values, graph)
+			name := match[1]
+			delete(imports, name)
+			if iterable.Kind == ValueQuerySet {
+				values[name] = Value{CanonicalLabel: iterable.CanonicalLabel, Kind: ValueModelInstance, Annotations: iterable.Annotations}
+			} else {
+				values[name] = Value{}
+			}
+			continue
+		}
 		if match := assignmentPattern.FindStringSubmatch(line); match != nil {
 			value := Value{}
 			if match[1] == "self" && strings.TrimSpace(match[2]) == "__pogo_model_receiver__" {
@@ -493,6 +523,14 @@ func buildEnvironmentAtPath(source []byte, graph *schema.Graph, syntax []SyntaxS
 			}
 			delete(imports, match[1])
 			values[match[1]] = value
+		}
+	}
+	for _, binding := range pendingForBindings {
+		delete(imports, binding.variable)
+		delete(values, binding.variable)
+		iterable := resolveExpression(binding.iterable, imports, values, graph)
+		if iterable.Kind == ValueQuerySet {
+			values[binding.variable] = Value{CanonicalLabel: iterable.CanonicalLabel, Kind: ValueModelInstance, Annotations: iterable.Annotations}
 		}
 	}
 	for _, name := range guardedBindings {
@@ -849,7 +887,7 @@ func splitBindingTargets(target string) []string {
 
 func recognizedEnvironmentStatement(text string) bool {
 	line := strings.TrimSpace(strings.TrimSuffix(text, "\r"))
-	return fromImportPattern.MatchString(line) || importPattern.MatchString(line) || annotationPattern.MatchString(line) || assignmentPattern.MatchString(line)
+	return fromImportPattern.MatchString(line) || importPattern.MatchString(line) || annotationPattern.MatchString(line) || assignmentPattern.MatchString(line) || forHeaderPattern.MatchString(line)
 }
 
 func resolveExpression(expression string, imports map[string]string, values map[string]Value, graph *schema.Graph) Value {
@@ -939,8 +977,10 @@ func resolveExpression(expression string, imports map[string]string, values map[
 		}
 		name := expression[nameStart:position]
 		called := false
+		callOpen := -1
 		position = skipExpressionSpace(expression, position)
 		if position < len(expression) && expression[position] == '(' {
+			callOpen = position
 			end, ok := skipCall(expression, position)
 			if !ok {
 				return Value{}
@@ -978,10 +1018,26 @@ func resolveExpression(expression string, imports map[string]string, values map[
 			}
 			switch name {
 			case "get", "first", "last", "create":
+				annotations := value.Annotations
 				value.Kind = ValueModelInstance
 				value.ManagerName = ""
 				value.QuerySetClass = ""
-			case "all", "filter", "exclude", "annotate", "alias", "distinct", "order_by", "values", "values_list", "only", "defer", "select_related", "prefetch_related":
+				value.Annotations = annotations
+			case "annotate", "alias":
+				if value.Kind == ValueManager {
+					value.ManagerName = ""
+				}
+				value.Kind = ValueQuerySet
+				if callOpen >= 0 && position > callOpen+1 {
+					newAliases := annotationKeywordNames(expression[callOpen+1 : position-1])
+					if len(newAliases) > 0 {
+						merged := make([]string, len(value.Annotations)+len(newAliases))
+						copy(merged, value.Annotations)
+						copy(merged[len(value.Annotations):], newAliases)
+						value.Annotations = merged
+					}
+				}
+			case "all", "filter", "exclude", "distinct", "order_by", "values", "values_list", "only", "defer", "select_related", "prefetch_related":
 				if value.Kind == ValueManager {
 					value.ManagerName = ""
 				}
@@ -1011,6 +1067,83 @@ func resolveExpression(expression string, imports map[string]string, values map[
 		}
 	}
 	return value
+}
+
+// annotationKeywordNames extracts keyword argument names from a call's argument string.
+// For example, "has_books=Exists(qs), count=Count('id')" returns ["has_books", "count"].
+func annotationKeywordNames(args string) []string {
+	var names []string
+	depth := 0
+	segStart := 0
+	var quote byte
+	escaped := false
+	for index := 0; index <= len(args); index++ {
+		var ch byte
+		if index < len(args) {
+			ch = args[index]
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',', 0:
+			if depth == 0 {
+				if name, ok := keywordArgName(args[segStart:index]); ok {
+					names = append(names, name)
+				}
+				segStart = index + 1
+			}
+		}
+	}
+	return names
+}
+
+func keywordArgName(segment string) (string, bool) {
+	segment = strings.TrimSpace(segment)
+	for index := 0; index < len(segment); index++ {
+		ch := segment[index]
+		switch ch {
+		case '(', '[', '{':
+			return "", false
+		case '=':
+			if index > 0 {
+				prev := segment[index-1]
+				if prev != '!' && prev != '<' && prev != '>' {
+					next := byte(0)
+					if index+1 < len(segment) {
+						next = segment[index+1]
+					}
+					if next != '=' {
+						name := strings.TrimSpace(segment[:index])
+						if identifierText(name) {
+							return name, true
+						}
+					}
+				}
+			}
+			return "", false
+		}
+	}
+	return "", false
 }
 
 func relatedManagerModel(field *schema.FieldRef) (string, bool) {

--- a/internal/analysis/infer_test.go
+++ b/internal/analysis/infer_test.go
@@ -277,6 +277,129 @@ func TestAnalyzeSyntaxSupportsParenthesizedMultilineAssignment(t *testing.T) {
 	}
 }
 
+func TestAnnotateAliasesTrackedOnQuerySet(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	tests := []struct {
+		name        string
+		source      string
+		annotations []string
+	}{
+		{
+			"single alias",
+			"from myapp.models import Author\nqs = Author.objects.annotate(has_books=Exists(published))\nqs.fi|",
+			[]string{"has_books"},
+		},
+		{
+			"alias method",
+			"from myapp.models import Author\nqs = Author.objects.alias(book_count=Count('books'))\nqs.fi|",
+			[]string{"book_count"},
+		},
+		{
+			"preserved through filter",
+			"from myapp.models import Author\nqs = Author.objects.annotate(has_books=Exists(published)).filter(name='x')\nqs.fi|",
+			[]string{"has_books"},
+		},
+		{
+			"multiple annotate calls",
+			"from myapp.models import Author\nqs = Author.objects.annotate(a=Value(1)).annotate(b=Value(2))\nqs.fi|",
+			[]string{"a", "b"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, offset := sourceAtCursor(t, test.source)
+			context, ok := Analyze(source, offset, graph)
+			if !ok || context.Kind != ContextMethodMember {
+				t.Fatalf("Analyze() = %#v, %v", context, ok)
+			}
+			if len(context.Value.Annotations) != len(test.annotations) {
+				t.Fatalf("Annotations = %v, want %v", context.Value.Annotations, test.annotations)
+			}
+			for i, want := range test.annotations {
+				if context.Value.Annotations[i] != want {
+					t.Errorf("Annotations[%d] = %q, want %q", i, context.Value.Annotations[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestAnnotateAliasesCarriedToModelInstance(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	tests := []struct {
+		name        string
+		source      string
+		annotations []string
+	}{
+		{
+			"via first()",
+			"from myapp.models import Author\nauthor = Author.objects.annotate(has_books=Exists(p)).first()\nauthor.has|",
+			[]string{"has_books"},
+		},
+		{
+			"via get()",
+			"from myapp.models import Author\nauthor = Author.objects.annotate(has_books=Exists(p)).get(pk=1)\nauthor.has|",
+			[]string{"has_books"},
+		},
+		{
+			"multiple aliases via last()",
+			"from myapp.models import Author\nauthor = Author.objects.annotate(a=Value(1), b=Value(2)).last()\nauthor.a|",
+			[]string{"a", "b"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, offset := sourceAtCursor(t, test.source)
+			context, ok := Analyze(source, offset, graph)
+			if !ok || context.Kind != ContextInstanceMember {
+				t.Fatalf("Analyze() = %#v, %v", context, ok)
+			}
+			if len(context.Value.Annotations) != len(test.annotations) {
+				t.Fatalf("Annotations = %v, want %v", context.Value.Annotations, test.annotations)
+			}
+			for i, want := range test.annotations {
+				if context.Value.Annotations[i] != want {
+					t.Errorf("Annotations[%d] = %q, want %q", i, context.Value.Annotations[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestAnnotateAliasesCarriedThroughForLoop(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	store := newTestStore(t)
+	uri := "file:///annotate-for.py"
+	sourceWithCursor := "from myapp.models import Author\nqs = Author.objects.annotate(has_books=Exists(p))\nfor author in qs:\n    author.has|"
+	source, offset := sourceAtCursor(t, sourceWithCursor)
+	if err := store.Open(uri, 1, string(source)); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, _ := store.Snapshot(uri)
+	context, ok := AnalyzeSyntax(snapshot.Source, offset, graph, snapshot.Syntax)
+	if !ok || context.Kind != ContextInstanceMember || context.Value.CanonicalLabel != "myapp.Author" {
+		t.Fatalf("AnalyzeSyntax() = %#v, %v", context, ok)
+	}
+	if len(context.Value.Annotations) != 1 || context.Value.Annotations[0] != "has_books" {
+		t.Fatalf("Annotations = %v, want [has_books]", context.Value.Annotations)
+	}
+}
+
+func TestForLoopErasesReboundModelName(t *testing.T) {
+	graph := inferenceTestGraph(t)
+	store := newTestStore(t)
+	uri := "file:///for-rebind.py"
+	sourceWithCursor := "from myapp.models import Author\nfor Author in values:\n    Author.na|"
+	source, offset := sourceAtCursor(t, sourceWithCursor)
+	if err := store.Open(uri, 1, string(source)); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, _ := store.Snapshot(uri)
+	if context, ok := AnalyzeSyntax(snapshot.Source, offset, graph, snapshot.Syntax); ok {
+		t.Fatalf("for-rebind should not infer model: %#v", context)
+	}
+}
+
 func sourceAtCursor(t *testing.T, value string) ([]byte, int) {
 	t.Helper()
 	if strings.Count(value, "|") != 1 {

--- a/internal/analysis/path.go
+++ b/internal/analysis/path.go
@@ -693,6 +693,18 @@ func pathMethod(method string) (PathMode, bool, bool) {
 	}
 }
 
+func isAnnotationAlias(annotations []string, name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, alias := range annotations {
+		if alias == name {
+			return true
+		}
+	}
+	return false
+}
+
 func isSpace(value byte) bool {
 	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
 }
@@ -749,8 +761,11 @@ func ResolvePathSegment(graph *schema.Graph, canonicalLabel string, mode PathMod
 	return resolved, true
 }
 
-func ValidatePath(graph *schema.Graph, canonicalLabel string, mode PathMode, segments []PathSegment) (PathIssue, bool) {
+func ValidatePath(graph *schema.Graph, canonicalLabel string, mode PathMode, segments []PathSegment, annotations []string) (PathIssue, bool) {
 	if graph == nil || canonicalLabel == "" || len(segments) == 0 || len(segments) > MaxPathSegments {
+		return PathIssue{}, false
+	}
+	if (mode == PathLookup || mode == PathProjection) && isAnnotationAlias(annotations, segments[0].Text) {
 		return PathIssue{}, false
 	}
 	state := resolverState{model: canonicalLabel}

--- a/internal/analysis/path.go
+++ b/internal/analysis/path.go
@@ -155,7 +155,7 @@ func analyzeExpressionPathContext(source []byte, offset int, graph *schema.Graph
 		return Context{}, false
 	}
 	imports, _ := buildEnvironmentAtPath(source[:offset], graph, syntax, offset, filePath)
-	if !strings.HasPrefix(expandImport(expression.name, imports), "django.db.models.functions.") {
+	if !isAnnotationExpressionFunction(expandImport(expression.name, imports)) {
 		return Context{}, false
 	}
 	call, ok := enclosingCallBefore(source, offset, expression.opening)
@@ -690,6 +690,22 @@ func pathMethod(method string) (PathMode, bool, bool) {
 		return PathPrefetchRelated, true, true
 	default:
 		return 0, false, false
+	}
+}
+
+// isAnnotationExpressionFunction reports whether a qualified callee refers to a Django ORM
+// expression whose positional string arguments name a field or annotation alias on the current
+// queryset (F(...), the aggregate functions, or anything under django.db.models.functions).
+func isAnnotationExpressionFunction(qualifiedName string) bool {
+	if strings.HasPrefix(qualifiedName, "django.db.models.functions.") {
+		return true
+	}
+	switch qualifiedName {
+	case "django.db.models.F", "django.db.models.Count", "django.db.models.Sum", "django.db.models.Avg",
+		"django.db.models.Min", "django.db.models.Max", "django.db.models.StdDev", "django.db.models.Variance":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/lsp/features.go
+++ b/internal/lsp/features.go
@@ -179,6 +179,11 @@ func (features *Features) Completion(uri string, position analysis.Position) (*p
 			}
 			return true
 		})
+		for _, alias := range context.Value.Annotations {
+			if strings.HasPrefix(alias, context.Identifier) {
+				items = append(items, annotationCompletion(alias, replacement))
+			}
+		}
 	case analysis.ContextInstanceMember:
 		graph.VisitInstanceFields(context.Value.CanonicalLabel, func(access schema.FieldAccess) bool {
 			if strings.HasPrefix(access.Name, context.Identifier) {
@@ -186,6 +191,11 @@ func (features *Features) Completion(uri string, position analysis.Position) (*p
 			}
 			return true
 		})
+		for _, alias := range context.Value.Annotations {
+			if strings.HasPrefix(alias, context.Identifier) {
+				items = append(items, annotationCompletion(alias, replacement))
+			}
+		}
 	case analysis.ContextModelMember:
 		graph.VisitInstanceFields(context.Value.CanonicalLabel, func(access schema.FieldAccess) bool {
 			if strings.HasPrefix(access.Name, context.Identifier) {
@@ -205,6 +215,13 @@ func (features *Features) Completion(uri string, position analysis.Position) (*p
 		}
 		for _, candidate := range analysis.CompletePath(graph, context.Value.CanonicalLabel, context.Path.Mode, context.Path.Segments, context.Path.ActiveSegment) {
 			items = append(items, pathCompletion(candidate, replacement))
+		}
+		if context.Path.ActiveSegment == 0 && (context.Path.Mode == analysis.PathLookup || context.Path.Mode == analysis.PathProjection) {
+			for _, alias := range context.Value.Annotations {
+				if strings.HasPrefix(alias, context.Identifier) {
+					items = append(items, annotationCompletion(alias, replacement))
+				}
+			}
 		}
 	case analysis.ContextMethodMember:
 		analysis.VisitMethods(graph, context.Value, func(method *schema.MethodRef) bool {
@@ -246,6 +263,21 @@ func (features *Features) Hover(uri string, position analysis.Position) (*protoc
 		}
 		resolved, exists := analysis.ResolvePathSegment(graph, context.Value.CanonicalLabel, context.Path.Mode, context.Path.Segments, context.Path.ActiveSegment)
 		if !exists || resolved.Field == nil || resolved.Text == "" {
+			if context.Path.ActiveSegment == 0 && (context.Path.Mode == analysis.PathLookup || context.Path.Mode == analysis.PathProjection) {
+				for _, alias := range context.Value.Annotations {
+					if alias == context.Identifier {
+						range_, valid := protocolRange(snapshot.Source, context.Replacement)
+						if !valid {
+							return nil, nil
+						}
+						content := annotationHoverMarkdown(alias, snapshot.Source, offset, graph, snapshot.Syntax, filePath)
+						return &protocol.Hover{
+							Contents: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: content},
+							Range:    &range_,
+						}, nil
+					}
+				}
+			}
 			return nil, nil
 		}
 		range_, valid := protocolRange(snapshot.Source, resolved.Range)
@@ -271,7 +303,35 @@ func (features *Features) Hover(uri string, position analysis.Position) (*protoc
 		return &protocol.Hover{Contents: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: methodMarkdown(context.Method)}, Range: &range_}, nil
 	case analysis.ContextQueryKeyword:
 		field, ok = graph.QueryAccess(context.Value.CanonicalLabel, context.Identifier)
+		if !ok || field.Field == nil {
+			for _, alias := range context.Value.Annotations {
+				if alias == context.Identifier {
+					range_, valid := protocolRange(snapshot.Source, context.Replacement)
+					if !valid {
+						return nil, nil
+					}
+					content := annotationHoverMarkdown(alias, snapshot.Source, offset, graph, snapshot.Syntax, filePath)
+					return &protocol.Hover{
+						Contents: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: content},
+						Range:    &range_,
+					}, nil
+				}
+			}
+		}
 	case analysis.ContextInstanceMember:
+		for _, alias := range context.Value.Annotations {
+			if alias == context.Identifier {
+				range_, valid := protocolRange(snapshot.Source, context.Replacement)
+				if !valid {
+					return nil, nil
+				}
+				content := annotationHoverMarkdown(alias, snapshot.Source, offset, graph, snapshot.Syntax, filePath)
+				return &protocol.Hover{
+					Contents: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: content},
+					Range:    &range_,
+				}, nil
+			}
+		}
 		field, ok = graph.InstanceAccess(context.Value.CanonicalLabel, context.Identifier)
 	case analysis.ContextModelMember:
 		manager, exists := graph.Manager(context.Value.CanonicalLabel, context.Identifier)
@@ -339,6 +399,14 @@ func (features *Features) SignatureHelp(uri string, position analysis.Position) 
 	return help, nil
 }
 
+func annotationHoverMarkdown(alias string, source []byte, offset int, graph *schema.Graph, syntax []analysis.SyntaxStatement, filePath string) string {
+	content := fmt.Sprintf("**%s**  \nQuerySet annotation", markdownText(alias))
+	if returnType, ok := analysis.AnnotationReturnType(source, offset, graph, syntax, filePath); ok {
+		content += fmt.Sprintf("\n\n- Return type: `%s`", markdownCode(returnType))
+	}
+	return content
+}
+
 func fieldCompletion(access schema.FieldAccess, replacement protocol.Range) protocol.CompletionItem {
 	kind := protocol.CompletionItemKindField
 	detail := access.Field.Type()
@@ -351,6 +419,20 @@ func fieldCompletion(access schema.FieldAccess, replacement protocol.Range) prot
 		Documentation: documentation,
 		SortText:      &sortText,
 		TextEdit:      protocol.TextEdit{Range: replacement, NewText: access.Name},
+	}
+}
+
+func annotationCompletion(name string, replacement protocol.Range) protocol.CompletionItem {
+	kind := protocol.CompletionItemKindField
+	detail := "QuerySet annotation"
+	sortText := "1-" + name
+	return protocol.CompletionItem{
+		Label:         name,
+		Kind:          &kind,
+		Detail:        &detail,
+		Documentation: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: fmt.Sprintf("**%s**  \nQuerySet annotation", markdownText(name))},
+		SortText:      &sortText,
+		TextEdit:      protocol.TextEdit{Range: replacement, NewText: name},
 	}
 }
 

--- a/internal/lsp/features_test.go
+++ b/internal/lsp/features_test.go
@@ -100,6 +100,161 @@ func TestManagerAndInstanceCompletion(t *testing.T) {
 	}
 }
 
+func TestAnnotateAliasCompletionAndHover(t *testing.T) {
+	features := testFeatures(t)
+	defer features.Close()
+	uri := "file:///annotate.py"
+	source := "from myapp.models import Author\nauthor = Author.objects.annotate(has_books=Exists(p)).first()\nauthor.has_books\n"
+	if err := features.documents.Open(uri, 1, source); err != nil {
+		t.Fatal(err)
+	}
+
+	completion, err := features.Completion(uri, analysis.Position{Line: 2, Character: 7})
+	if err != nil {
+		t.Fatalf("Completion() error = %v", err)
+	}
+	if completion == nil {
+		t.Fatal("Completion() = nil, want alias in results")
+	}
+	found := false
+	for _, item := range completion.Items {
+		if item.Label == "has_books" {
+			found = true
+			if item.Detail == nil || *item.Detail != "QuerySet annotation" {
+				t.Errorf("completion detail = %v, want 'QuerySet annotation'", item.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("completion items = %v, want has_books", completion.Items)
+	}
+
+	hover, err := features.Hover(uri, analysis.Position{Line: 2, Character: 10})
+	if err != nil {
+		t.Fatalf("Hover() error = %v", err)
+	}
+	if hover == nil {
+		t.Fatal("Hover() = nil, want annotation hover")
+	}
+	markup, ok := hover.Contents.(protocol.MarkupContent)
+	if !ok || !strings.Contains(markup.Value, "**has\\_books**") || !strings.Contains(markup.Value, "QuerySet annotation") {
+		t.Errorf("hover contents = %#v", hover.Contents)
+	}
+}
+
+func TestAnnotateAliasORMPathCompletionAndHover(t *testing.T) {
+	features := testFeatures(t)
+	defer features.Close()
+	uri := "file:///annotate-path.py"
+	source := "from myapp.models import Author\nAuthor.objects.annotate(count=Count(\"id\")).values_list(\"pk\", \"count\")\n"
+	if err := features.documents.Open(uri, 1, source); err != nil {
+		t.Fatal(err)
+	}
+
+	completion, err := features.Completion(uri, analysis.Position{Line: 1, Character: 64})
+	if err != nil {
+		t.Fatalf("Completion() error = %v", err)
+	}
+	if completion == nil {
+		t.Fatal("Completion() = nil, want alias in results")
+	}
+	found := false
+	for _, item := range completion.Items {
+		if item.Label == "count" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("completion items = %v, want count", completion.Items)
+	}
+
+	hover, err := features.Hover(uri, analysis.Position{Line: 1, Character: 65})
+	if err != nil {
+		t.Fatalf("Hover() error = %v", err)
+	}
+	if hover == nil {
+		t.Fatal("Hover() = nil, want annotation hover")
+	}
+	markup, ok := hover.Contents.(protocol.MarkupContent)
+	if !ok || !strings.Contains(markup.Value, "**count**") || !strings.Contains(markup.Value, "QuerySet annotation") || !strings.Contains(markup.Value, "Return type") || !strings.Contains(markup.Value, "`int`") {
+		t.Errorf("hover contents = %#v", hover.Contents)
+	}
+}
+
+func TestAnnotateAliasBareKeywordHoverShowsReturnType(t *testing.T) {
+	features := testFeatures(t)
+	defer features.Close()
+	uri := "file:///annotate-keyword.py"
+	source := "from myapp.models import Author\nAuthor.objects.annotate(has_books=Exists(x)).filter(has_books=True)\n"
+	if err := features.documents.Open(uri, 1, source); err != nil {
+		t.Fatal(err)
+	}
+	hover, err := features.Hover(uri, analysis.Position{Line: 1, Character: 56})
+	if err != nil {
+		t.Fatalf("Hover() error = %v", err)
+	}
+	if hover == nil {
+		t.Fatal("Hover() = nil, want annotation hover")
+	}
+	markup, ok := hover.Contents.(protocol.MarkupContent)
+	if !ok || !strings.Contains(markup.Value, "**has\\_books**") || !strings.Contains(markup.Value, "`bool`") {
+		t.Errorf("hover contents = %#v", hover.Contents)
+	}
+}
+
+func TestAnnotateAliasInsideFExpressionHover(t *testing.T) {
+	features := testFeatures(t)
+	defer features.Close()
+	uri := "file:///annotate-f-expr.py"
+	source := "from django.db.models import F, Count\nfrom myapp.models import Author\nAuthor.objects.annotate(user_count=Count(\"id\")).annotate(total=F(\"user_count\") + 1)\n"
+	if err := features.documents.Open(uri, 1, source); err != nil {
+		t.Fatal(err)
+	}
+
+	completion, err := features.Completion(uri, analysis.Position{Line: 2, Character: 70})
+	if err != nil {
+		t.Fatalf("Completion() error = %v", err)
+	}
+	if completion == nil {
+		t.Fatal("Completion() = nil, want alias in results")
+	}
+	found := false
+	for _, item := range completion.Items {
+		if item.Label == "user_count" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("completion items = %v, want user_count", completion.Items)
+	}
+
+	hover, err := features.Hover(uri, analysis.Position{Line: 2, Character: 70})
+	if err != nil {
+		t.Fatalf("Hover() error = %v", err)
+	}
+	if hover == nil {
+		t.Fatal("Hover() = nil, want annotation hover")
+	}
+	markup, ok := hover.Contents.(protocol.MarkupContent)
+	if !ok || !strings.Contains(markup.Value, "**user\\_count**") || !strings.Contains(markup.Value, "QuerySet annotation") || !strings.Contains(markup.Value, "`int`") {
+		t.Errorf("hover contents = %#v", hover.Contents)
+	}
+
+	location, err := features.Definition(uri, analysis.Position{Line: 2, Character: 70})
+	if err != nil || location == nil {
+		t.Fatalf("Definition() = %#v, %v", location, err)
+	}
+	if string(location.URI) != uri {
+		t.Fatalf("Definition() URI = %s, want %s", location.URI, uri)
+	}
+	snapshot, _ := features.documents.Snapshot(uri)
+	start, startOK := analysis.ByteOffset(snapshot.Source, analysis.Position{Line: uint32(location.Range.Start.Line), Character: uint32(location.Range.Start.Character)})
+	end, endOK := analysis.ByteOffset(snapshot.Source, analysis.Position{Line: uint32(location.Range.End.Line), Character: uint32(location.Range.End.Character)})
+	if !startOK || !endOK || string(snapshot.Source[start:end]) != "user_count" || end >= len(snapshot.Source) || snapshot.Source[end] != '=' {
+		t.Fatalf("Definition() range = %#v, text %q", location.Range, snapshot.Source[start:min(end+1, len(snapshot.Source))])
+	}
+}
+
 func TestModelSelfRelationChainCompletionAndHover(t *testing.T) {
 	features := testFeatures(t)
 	defer features.Close()

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -43,14 +43,22 @@ func (features *Features) Definition(uri string, position analysis.Position) (*p
 	if !ok {
 		sourceRange, ok = analysis.ResolveDefinitionSyntaxFile(snapshot.Source, offset, graph, snapshot.Syntax, filePath)
 	}
+	if ok {
+		location, valid := features.sourceLocation(sourceRange)
+		if !valid {
+			return nil, nil
+		}
+		return &location, nil
+	}
+	aliasRange, ok := analysis.ResolveAnnotationAliasDefinition(snapshot.Source, offset, graph, snapshot.Syntax, filePath)
 	if !ok {
 		return nil, nil
 	}
-	location, ok := features.sourceLocation(sourceRange)
-	if !ok {
+	range_, valid := protocolRange(snapshot.Source, aliasRange)
+	if !valid {
 		return nil, nil
 	}
-	return &location, nil
+	return &protocol.Location{URI: protocol.DocumentUri(uri), Range: range_}, nil
 }
 
 func (features *Features) sourceLocation(sourceRange schema.SourceRange) (protocol.Location, bool) {

--- a/internal/lsp/navigation_test.go
+++ b/internal/lsp/navigation_test.go
@@ -78,6 +78,41 @@ func TestDefinitionReturnsExactSchemaLocations(t *testing.T) {
 	}
 }
 
+func TestDefinitionResolvesAnnotationAliasWithinDocument(t *testing.T) {
+	features, _ := navigationTestFeatures(t)
+	defer features.Close()
+	uri := "file:///workspace/annotate-queries.py"
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"values_list argument", "from myapp.models import Book\nBook.objects.annotate(count=Count(\"id\")).values_list(\"title\", \"cou|nt\")"},
+		{"filter lookup", "from myapp.models import Book\nBook.objects.annotate(count=Count(\"id\")).filter(cou|nt__gt=1)"},
+	}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, position := lspSourceAtCursor(t, test.source)
+			if err := features.documents.Open(uri, int32(index+1), string(source)); err != nil {
+				t.Fatal(err)
+			}
+			location, err := features.Definition(uri, position)
+			if err != nil || location == nil {
+				t.Fatalf("Definition() = %#v, %v", location, err)
+			}
+			if string(location.URI) != uri {
+				t.Fatalf("Definition() URI = %s, want %s", location.URI, uri)
+			}
+			snapshot, _ := features.documents.Snapshot(uri)
+			start, startOK := analysis.ByteOffset(snapshot.Source, analysis.Position{Line: uint32(location.Range.Start.Line), Character: uint32(location.Range.Start.Character)})
+			end, endOK := analysis.ByteOffset(snapshot.Source, analysis.Position{Line: uint32(location.Range.End.Line), Character: uint32(location.Range.End.Character)})
+			if !startOK || !endOK || string(snapshot.Source[start:end]) != "count" || end >= len(snapshot.Source) || snapshot.Source[end] != '=' {
+				t.Fatalf("Definition() range = %#v, text %q", location.Range, snapshot.Source[start:min(end+1, len(snapshot.Source))])
+			}
+			features.documents.Close(uri)
+		})
+	}
+}
+
 func TestDefinitionSoftFailsForMissingAndInvalidTargets(t *testing.T) {
 	features, modelsPath := navigationTestFeatures(t)
 	defer features.Close()


### PR DESCRIPTION
## Summary
- Fix a false-positive `django-orm.unknown-path-segment` diagnostic where a `.annotate(alias=...)`/`.alias(...)` alias referenced later in `values()`/`values_list()`/`filter()`/`exclude()`/`get()` was flagged as an unknown field.
- Add hover, completion, and go-to-definition for annotation aliases across every shape they can appear in: `values()`/`values_list()`, bare-keyword and `__lookup` forms of `filter()`/`exclude()`/`get()`, nested inside `Q(...)`, attribute access on a resolved model instance (`obj.alias`), and string arguments to `F(...)`/aggregate functions referencing an alias defined in an earlier `.annotate()` call in the same chain.
- Infer and show the annotation's Python return type in hover where possible (`Count` → `int`, `Exists` → `bool`, `Sum`/`Avg`/`Min`/`Max`/`F` resolve the referenced field's real Django type, `Value(...)` infers from the literal, explicit `output_field=` always wins).

## Test plan
- [x] `go test -tags=grammar_subset,grammar_subset_python ./internal/...`
- [x] `gofmt -l` / `go vet` clean
- [x] `make build`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Sdu7FFzuRNqk8J5Akxv8fF